### PR TITLE
Added a message to help debug bad input files

### DIFF
--- a/tightbind/fileio.c
+++ b/tightbind/fileio.c
@@ -512,6 +512,7 @@ void fill_atomic_parms(atoms,num_atoms,infile)
       its parameters from the input file
       ********/
     else if(atoms[i].symb[0] == '*'){
+      printf("Looking for parameters for special atom in the input file...\n");
       skipcomments(infile,instring,FATAL);
       num_read = sscanf(instring,"%s %d %d %d %lf %lf %d %lf %lf %d %lf %lf %lf %lf %lf %d %lf %lf %lf %lf %lf",
                         custom_atoms[num_custom].symb,


### PR DESCRIPTION
Instead of just saying the following:

FATAL ERROR: End of File (EOF) hit in skipcomments..
Execution Terminated.

when a custom atom's parameters are not found, I added
a message that says it is looking for the custom atom's
parameters right before that message comes up. That can
help people debug their problems with their input files.
