### PR TITLE
Removed some of the printing during runtime

### DIFF
--- a/tightbind/FMO_stuff.c
+++ b/tightbind/FMO_stuff.c
@@ -410,7 +410,8 @@ void diagonalize_FMO(details,work1,work2,work3,cmplx_hamil,cmplx_overlap,cmplx_w
       itype = 1;
       if( details->just_avgE ){
         jobz = 'N';
-        fprintf(stdout,".");
+        if( print_progress )
+          fprintf(stdout,".");
       } else{
         jobz = 'V';
       }

--- a/tightbind/R_overlap_mat.c
+++ b/tightbind/R_overlap_mat.c
@@ -847,8 +847,8 @@ printmat(overlap,num_orbs,num_orbs,status_file,1e-10,0,details->line_width);
                   orbital_lookup_table);
   }
 
-
-fprintf(stdout,".\n");
+if( print_progress)
+  fprintf(stdout,".\n");
 
 
 #if 0

--- a/tightbind/bands.c
+++ b/tightbind/bands.c
@@ -255,7 +255,9 @@ void construct_band_structure(cell,details,overlapR,hamilR,overlapK,hamilK,
     default:
       FATAL_BUG("Somehow a bogus execution mode got passed to generate_band_structure.");
     }
-fprintf(stderr,">");
+
+if( print_progress )
+  fprintf(stderr,">");
 
     /******
       The matrix diagonalization routine destroys the overlap matrix,
@@ -302,7 +304,10 @@ fprintf(stderr,">");
     jobz = 'N';
     uplo = 'L';
     num_orbs2 = num_orbs*num_orbs;
-    fprintf(stderr,"{");
+
+    if( print_progress)
+      fprintf(stderr,"{");
+
     if(!details->diag_wo_overlap){
       zhegv((long *)&(itype),&jobz,&uplo,(long *)&num_orbs,cmplx_hamil,
                               (long *)&num_orbs,cmplx_overlap,
@@ -312,10 +317,14 @@ fprintf(stderr,">");
       zheev(&jobz,&uplo,(long *)&num_orbs,cmplx_hamil,(long *)&num_orbs,
                                     eigenset.val,cmplx_work,(long *)&num_orbs2,work3,(long *)&diag_error);
     }
-    fprintf(stderr,"}");
+
+    if( print_progress )
+      fprintf(stderr,"}");
 #endif
 
-    fprintf(stderr,"<\n");
+    if( print_progress )
+      fprintf(stderr,"<\n");
+
     fprintf(status_file,"Error value from Diagonalization (0 is good): %d\n",diag_error);
 
 

--- a/tightbind/bind.h
+++ b/tightbind/bind.h
@@ -71,6 +71,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fcntl.h>
 #include <math.h>
 #include <signal.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -930,5 +931,7 @@ extern avg_prop_info_type *avg_prop_info;
 extern K_orb_ptr_type *orbital_ordering;
 
 extern real electrostatic_term, eHMO_term, total_energy;
+
+extern bool print_progress; // Shall we print progress during calculations?
 
 #include "prototypes.h"

--- a/tightbind/fileio.c
+++ b/tightbind/fileio.c
@@ -73,8 +73,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Include the default data in case we need it
 #include "eht_parms.h"
 
-#include "stdbool.h" // standard booleans
-
 /* hopefully this will be way more than enough */
 #define MAX_CUSTOM_ATOMS 40
 atom_type custom_atoms[MAX_CUSTOM_ATOMS];
@@ -2695,6 +2693,12 @@ calculation.\n");
           skipcomments(infile,instring,FATAL);
           sscanf(instring,"%d",&details->line_width);
         }
+      }
+      // This is just for printing symbols to indicate where we are in our
+      // progress
+      else if(strstr(instring,"SHOW PROGRESS")){
+        fprintf(status_file,"Progress will be printed during calculations.\n");
+        print_progress = true;
       }
 
       /*----------------------------------------------------------------------*/

--- a/tightbind/globals.c
+++ b/tightbind/globals.c
@@ -73,3 +73,5 @@ sym_op_type *sym_ops_present=0;
 prop_type properties;
 avg_prop_info_type *avg_prop_info;
 K_orb_ptr_type *orbital_ordering;
+
+bool print_progress = false;

--- a/tightbind/kpoints.c
+++ b/tightbind/kpoints.c
@@ -336,7 +336,9 @@ void loop_over_k_points(cell,details,overlapR,hamilR,overlapK,hamilK,
         /* generate the transform matrices */
         gen_FMO_tform_matrices(details);
       }
-      fprintf(stdout,"%d >",i+1);
+
+      if ( print_progress )
+        fprintf(stdout,"%d >",i+1);
 
 #ifndef USE_LAPACK
       /******
@@ -438,13 +440,15 @@ void loop_over_k_points(cell,details,overlapR,hamilR,overlapK,hamilK,
       itype = 1;
       if( details->just_avgE ){
         jobz = 'N';
-        fprintf(stdout,".");
+        if( print_progress )
+          fprintf(stdout,".");
       } else{
         jobz = 'V';
       }
       uplo = 'L';
       num_orbs2 = num_orbs*num_orbs;
-      fprintf(stdout,"{");
+      if( print_progress )
+        fprintf(stdout,"{");
       if(!details->diag_wo_overlap){
         zhegv((long *)&(itype),&jobz,&uplo,(long *)&num_orbs,cmplx_hamil,
                                 (long *)&num_orbs,cmplx_overlap,
@@ -455,7 +459,8 @@ void loop_over_k_points(cell,details,overlapR,hamilR,overlapK,hamilK,
               eigenset.val,cmplx_work,(long *)&num_orbs2,work3,
               (long *)&diag_error);
       }
-      fprintf(stdout,"}");
+      if( print_progress )
+        fprintf(stdout,"}");
 
       /* now copy stuff back out of the results */
       if( !details->just_avgE ){
@@ -470,7 +475,9 @@ void loop_over_k_points(cell,details,overlapR,hamilR,overlapK,hamilK,
       }
 #endif
 
-      fprintf(stdout,"<\n");
+      if( print_progress)
+        fprintf(stdout,"<\n");
+
       fprintf(status_file,"Error value from Diagonalization (0 is good): %d\n",
               diag_error);
       fflush(status_file);


### PR DESCRIPTION
Removed dot printing, space printing, and '<' or '>'
printing during runtime. It's somewhat inconvenient
to scroll all the way back up to the top to see
messages at the beginning of the run. So this fixes
that issue.
