### PR TITLE
User can now specify parameter file as a third arg

### DIFF
--- a/tightbind/fileio.c
+++ b/tightbind/fileio.c
@@ -410,6 +410,8 @@ void fill_chg_it_parms(atoms,num_atoms,num_lines,infile)
  * Arguments:  atoms: pointer to atom_type
  *         num_atoms: int
  *            infile: pointer to file type
+ *    parm_file_name: the name of the parameter file taken from the arguments.
+ *                    Put NULL if there is not one from the arguments.
  *
  * Returns: none
  *
@@ -420,13 +422,13 @@ void fill_chg_it_parms(atoms,num_atoms,num_lines,infile)
  *   EHT_PARM_FILE given above (or in the makefile)
  *
  *****************************************************************************/
-void fill_atomic_parms(atoms,num_atoms,infile)
+void fill_atomic_parms(atoms,num_atoms,infile,parm_file_name)
   atom_type *atoms;
   int num_atoms;
   FILE *infile;
+  char *parm_file_name;
 {
   char err_string[240],instring[80];
-  char *parm_file_name;
   point_type saveloc;
   Z_mat_type saveZloc;
   FILE *parmfile;
@@ -446,9 +448,8 @@ void fill_atomic_parms(atoms,num_atoms,infile)
 
   /* open the parameter file */
 #ifndef USING_THE_MAC
-  parm_file_name = (char *)getenv("BIND_PARM_FILE");
-#else
-  parm_file_name = 0;
+  if (!parm_file_name)
+    parm_file_name = (char *)getenv("BIND_PARM_FILE");
 #endif
   if( !parm_file_name ){
     parm_file_name = (char *)calloc(240,sizeof(char));
@@ -1434,6 +1435,8 @@ void parse_charge_iteration(infile,details,cell)
  *             name: pointer to type char
  *         num_orbs: pointer to int
  *     orbital_lookup_table: pointer to pointer to int
+ *    parm_file_name: the name of the parameter file taken from the arguments.
+ *                    Put NULL if there is not one from the arguments.
  *
  * Returns: none
  *
@@ -1441,13 +1444,15 @@ void parse_charge_iteration(infile,details,cell)
  *   the information is read into the two structures 'cell and 'details
  *
  *****************************************************************************/
-void read_inputfile(cell,details,name,num_orbs,orbital_lookup_table,the_file)
+void read_inputfile(cell,details,name,num_orbs,orbital_lookup_table,the_file,
+                    parm_file_name)
   cell_type *cell;
   detail_type *details;
   char *name;
   int *num_orbs;
   int **orbital_lookup_table;
   FILE *the_file;
+  char *parm_file_name;
 {
   walsh_details_type *walsh;
   band_info_type *band_info;
@@ -1553,7 +1558,7 @@ void read_inputfile(cell,details,name,num_orbs,orbital_lookup_table,the_file)
       we should call the new3 input routine.
       ******/
     safe_strcpy(details->title,instring);
-    read_NEW3file(cell,details,infile);
+    read_NEW3file(cell,details,infile,parm_file_name);
 
   }
   else{
@@ -1920,12 +1925,12 @@ done.\n");
           fill in the atomic parameters
 
           *************/
-        fill_atomic_parms(cell->atoms,cell->num_atoms,infile);
+        fill_atomic_parms(cell->atoms,cell->num_atoms,infile,parm_file_name);
 
         /* do the geom frags, if need be */
         geom_frag = cell->geom_frags;
         while(geom_frag){
-          fill_atomic_parms(geom_frag->atoms,geom_frag->num_atoms,infile);
+          fill_atomic_parms(geom_frag->atoms,geom_frag->num_atoms,infile,parm_file_name);
           geom_frag = geom_frag->next;
         }
 
@@ -2638,7 +2643,7 @@ calculation.\n");
           muller iteration parameters, get them now if we need to.
         ********/
         if( !got_params ){
-          fill_atomic_parms(cell->atoms,cell->num_atoms,infile);
+          fill_atomic_parms(cell->atoms,cell->num_atoms,infile,parm_file_name);
           got_params = 1;
         }
         parse_muller_parms(infile,details,cell);
@@ -2671,12 +2676,12 @@ calculation.\n");
       so read them in now
     ********/
     if(!got_params){
-      fill_atomic_parms(cell->atoms,cell->num_atoms,infile);
+      fill_atomic_parms(cell->atoms,cell->num_atoms,infile,parm_file_name);
 
       /* do the geom_frags if we need to */
       geom_frag = cell->geom_frags;
       while(geom_frag){
-        fill_atomic_parms(geom_frag->atoms,geom_frag->num_atoms,infile);
+        fill_atomic_parms(geom_frag->atoms,geom_frag->num_atoms,infile,parm_file_name);
         geom_frag = geom_frag->next;
       }
 

--- a/tightbind/main.c
+++ b/tightbind/main.c
@@ -102,9 +102,13 @@ char test_string[80];
 #endif
   /* make sure the program was called with the right arguments */
   if( argc < 2){
-    fprintf(stderr,"Usage: bind <inputfile>\n");
-    exit(666);
+    fprintf(stderr,"Usage: bind <inputfile> [paramfile]\n");
+    exit(-1);
   }
+  // If there is a third argument, it is the parameter file
+  char* parm_file_name = NULL;
+  if (argc > 2)
+    parm_file_name = argv[2];
 
   /* install the sig_int handler */
   signal(SIGINT,handle_sigint);
@@ -150,7 +154,7 @@ char test_string[80];
     read in the data
 
   *********/
-  read_inputfile(unit_cell,details,argv[1],&num_orbs,&orbital_lookup_table,the_file);
+  read_inputfile(unit_cell,details,argv[1],&num_orbs,&orbital_lookup_table,the_file,parm_file_name);
 
   /* copy the file name into the details structure */
   strcpy(details->filename,argv[1]);

--- a/tightbind/new3_fileio.c
+++ b/tightbind/new3_fileio.c
@@ -48,16 +48,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 * Arguments:  cell: pointer to cell_type
 *          details: pointer to detail_type
 *             name: pointer to type char
+*   parm_file_name: name of the parm file. NULL if none given in arguments
 *
 * Returns: none
 *
 * Action: reads all the data out of the file 'infile
 *
 *****************************************************************************/
-void read_NEW3file(cell,details,infile)
+void read_NEW3file(cell,details,infile,parm_file_name)
   cell_type *cell;
   detail_type *details;
   FILE *infile;
+  char *parm_file_name;
 {
   char err_string[240];
   char instring[90];
@@ -152,7 +154,7 @@ void read_NEW3file(cell,details,infile)
   }
 
   /* fill in the atomic parameters */
-  fill_atomic_parms(cell->atoms,cell->num_atoms,infile);
+  fill_atomic_parms(cell->atoms,cell->num_atoms,infile,parm_file_name);
   write_atom_coords(cell->atoms,cell->num_atoms,cell->using_Zmat,
                     cell->using_xtal_coords);
   write_atom_parms(details,cell->atoms,cell->num_atoms,1);

--- a/tightbind/prototypes.h
+++ b/tightbind/prototypes.h
@@ -152,10 +152,10 @@ PROTO((cell_type *, int, eigenset_type, real *, real *, int *, real *, real *,
 extern void read_geom_frag PROTO((FILE *, geom_frag_type *));
 extern void write_atom_parms PROTO((detail_type *, atom_type *, int, char));
 extern void write_atom_coords PROTO((atom_type *, int, char, char));
-extern void fill_atomic_parms PROTO((atom_type *, int, FILE *));
+extern void fill_atomic_parms PROTO((atom_type *, int, FILE *, char *));
 extern void parse_printing_options PROTO((FILE *, detail_type *, cell_type *));
 extern void read_inputfile
-PROTO((cell_type *, detail_type *, char *, int *, int **, FILE *));
+PROTO((cell_type *, detail_type *, char *, int *, int **, FILE *, char *));
 extern void fatal PROTO((char *));
 extern void fatal_bug PROTO((char *, char *, int));
 extern void nonfatal_bug PROTO((char *, char *, int));
@@ -211,7 +211,7 @@ PROTO((cell_type *, eigenset_type, hermetian_matrix_type, int, real *, int *,
 extern void modified_mulliken
 PROTO((cell_type *, eigenset_type, hermetian_matrix_type, int, real *, int *,
        real *, real *, real *, real *));
-extern void read_NEW3file PROTO((cell_type *, detail_type *, FILE *));
+extern void read_NEW3file PROTO((cell_type *, detail_type *, FILE *, char *));
 extern void find_princ_axes
 PROTO((atom_type *, point_type *, real[3][3], real[3], int));
 


### PR DESCRIPTION
If the user puts in a third argument, that will be used
as the parameter file. I also updated this for new3_fileio,
but I'm not sure if that was necessary since it doesn't
look like we use new3_fileio by default...
