### PR TITLE
Added options for linking to blas and lapack

### DIFF
--- a/tightbind/CMakeLists.txt
+++ b/tightbind/CMakeLists.txt
@@ -49,6 +49,25 @@ option(USE_F2C
    Note that you must be able to link to the f2c library for this to work."
   ON)
 
+# Should we use blas and lapack?
+option(USE_BLAS_LAPACK
+       "Whether or not to link to BLAS and LAPACK for much faster matrix
+       multiplication"
+       OFF)
+
+option(BUILD_STATIC
+       "Whether or not to build the entire executable as static"
+       OFF)
+
+# Using F2C and building statically is possible, but libf2c.a will likely have
+# a dynamic dependency (unless one built it from source themselves). So this
+# is probably not going to produce a purely static executable...
+# There seems to be some issues with this...
+if(USE_F2C AND BUILD_STATIC)
+  message(FATAL_ERROR
+          "We currently do not support both USE_F2C and BUILD_STATIC together.")
+endif(USE_F2C AND BUILD_STATIC)
+
 if(USE_F2C)
   # We link to the static library of F2C to avoid an error
   set(F2C_LIB "f2c.a")
@@ -62,10 +81,18 @@ if(USE_F2C)
   set(YAEHMOP_SRCS
     ${YAEHMOP_SRCS}
     f2c_files/abfns.c
-    f2c_files/cboris.c
-    f2c_files/diag.c
     f2c_files/lovlap.c
   )
+
+  # If we aren't using blas and lapack, we must build these as well
+  if(NOT USE_BLAS_LAPACK)
+    set(YAEHMOP_SRCS
+      ${YAEHMOP_SRCS}
+      f2c_files/cboris.c
+      f2c_files/diag.c
+    )
+  endif(NOT USE_BLAS_LAPACK)
+
 else(USE_F2C)
   message("-- Building without F2C. Fortran compilers ARE required.")
   # We have to find a Fortran compiler if we are not using F2C
@@ -73,10 +100,18 @@ else(USE_F2C)
   set(YAEHMOP_SRCS
     ${YAEHMOP_SRCS}
     abfns.f
-    cboris.f
-    diag.f
     lovlap.f
   )
+
+  # If we aren't using blas and lapack, we must build these as well
+  if(NOT USE_BLAS_LAPACK)
+    set(YAEHMOP_SRCS
+      ${YAEHMOP_SRCS}
+      cboris.f
+      diag.f
+    )
+  endif(NOT USE_BLAS_LAPACK)
+
 endif(USE_F2C)
 
 # We link to the static library to avoid an error
@@ -92,9 +127,55 @@ add_definitions(-DUNDERSCORE_FORTRAN)
 
 # Add the executable and link to the C math library
 add_executable(bind ${YAEHMOP_SRCS})
-target_link_libraries(bind m)
 
 # If we are using F2C, we have to link to the library
 if(USE_F2C)
   target_link_libraries(bind ${F2C_LIB})
 endif(USE_F2C)
+
+# If we are using LAPACK and BLAS, link to them
+if(USE_BLAS_LAPACK)
+  # Should we perform static or dynamic linkage? Default is dynamic
+  option(STATIC_BLAS_LAPACK
+         "If we are using blas and lapack, whether to link them statically "
+         OFF)
+
+  # If we are building a static executable, we must set this to on
+  if(BUILD_STATIC)
+    message("-- Linking to blas and lapack statically since BUILD_STATIC is on")
+    set(STATIC_BLAS_LAPACK ON)
+  endif(BUILD_STATIC)
+
+  if(STATIC_BLAS_LAPACK)
+    message("-- Using static linkage for blas and lapack")
+    message("-- Attempting to link to liblapack.a and libblas.a")
+    message("-- Note that we must also link to gfortran for static linking")
+    # We have to statically link to lapack and blas
+    target_link_libraries(bind liblapack.a libblas.a)
+    # Link these as well if we are not using MINGW
+    if(NOT MINGW)
+      target_link_libraries(bind libgfortran.a libquadmath.a)
+    endif(NOT MINGW)
+  else(STATIC_BLAS_LAPACK)
+    # If we are just linking to the dynamic libraries, cmake can find them
+    message("-- Dynamically linking to Lapack and Blas libraries.")
+    message("-- To statically link, use -DSTATIC_BLAS_LAPACK=ON")
+    find_package(LAPACK REQUIRED)
+    message("-- Lapack found")
+    message("-- Lapack and Blas libraries are: ${LAPACK_LIBRARIES}")
+    target_link_libraries(bind ${LAPACK_LIBRARIES})
+  endif(STATIC_BLAS_LAPACK)
+  # This is needed for the code
+  add_definitions(-DUSE_LAPACK)
+endif(USE_BLAS_LAPACK)
+
+if(BUILD_STATIC)
+  set(BUILD_SHARED_LIBRARIES OFF)
+  # We are probably going to need to change this if we allow for MSVC
+  # compilation. But we can cross that bridge later - we don't need MSVC
+  # compilation right now.
+  set(CMAKE_EXE_LINKER_FLAGS "-static")
+endif(BUILD_STATIC)
+
+# Link to the C Math library
+target_link_libraries(bind m)


### PR DESCRIPTION
When running cmake, the user can use the definition
-DUSE_BLAS_LAPACK=ON to link to blas and lapack for matrix
multiplication (instead of using cboris and diag subroutines
in yaehmop). It uses cmake to find blas and lapack and links
to them dynamically by default. If the user specifies
-DSTATIC_BLAS_LAPACK=ON as well, it will link to them
statically. I've tried every combination of those two definitions
with -DUSE_F2C=<ON/OFF>, and I've ran tests on diamond and they
all appear to work.
