### PR TITLE
Resize char array to prevent crashing on Mac

### DIFF
--- a/tightbind/fileio.c
+++ b/tightbind/fileio.c
@@ -431,7 +431,7 @@ void fill_atomic_parms(atoms,num_atoms,infile,parm_file_name)
   FILE *infile;
   char *parm_file_name;
 {
-  char err_string[240],instring[80];
+  char err_string[240],instring[240];
   point_type saveloc;
   Z_mat_type saveZloc;
   FILE *parmfile;


### PR DESCRIPTION
For some reason, when reading the default parameters that I
added, Mac will crash since there is not enough memory for the
strcpy, but Linux does not. I think we can allow for a little
more flexibility for the instring size. A size 240 should not
have a noticeable impact on performance. This fixes the Mac
issue I was noticing.
