### PR TITLE
Fixed a bug where cell vectors did not get initialized

### DIFF
--- a/tightbind/R_overlap_mat.c
+++ b/tightbind/R_overlap_mat.c
@@ -909,7 +909,7 @@ void R_space_overlap_matrix(cell,details,overlap,num_orbs,tot_overlaps,
   int overlap_tab;
 
   char found = 0;
-  point_type cell_dim[3];
+  static point_type cell_dim[3];
   point_type distances;
   real temp,min=100.0;
   int min_dir;


### PR DESCRIPTION
After about ~15 hours of research into why the program was crashing under special conditions, I found a bug fix that solved the crashing problems.

Here, cell_dim[3] gets initialized the first time the function is called, but it does not get initialized again. This relies on the value of cell_dim[] to stay the same between function calls (which results in undefined behavior).

Luckily, it looks like cell_dim[] would indeed often be the same between function calls. But not always. The rare cases where it did not resulted in ridiculous hamiltonians and lapack errors because it couldn't find the eigenvalues and eigenvectors of the bad hamiltonian. This resulted in crashing or very bad data.

Making the variable "static" so that there is exactly one copy in the program's memory keeps this from happening. The value is retained in between function calls, and the bug goes away.