### PR TITLE
Moved an increment to prevent crashing.

### DIFF
--- a/tightbind/fileio.c
+++ b/tightbind/fileio.c
@@ -286,16 +286,19 @@ void write_atom_parms(detail_type *details,atom_type *atoms,int num_atoms,
     }
     /* if we didn't find it... */
     if( !found_this_one ){
-      /* just copy the data into the unique_atoms array */
-      bcopy(&(atoms[i]),&(unique_atoms[num_unique_atoms]),
-            sizeof(atom_type));
-      num_unique_atoms++;
+      /* resize if needed -- WARNING: this region has seemingly been the
+         cause of some crashes. This may need to be changed */
       if( num_unique_atoms == max_num_unique ){
         max_num_unique += num_atoms;
         unique_atoms = (atom_type *)my_realloc((int *)unique_atoms,
                                             max_num_unique*sizeof(atom_type));
         if( !unique_atoms ) fatal("Can't realloc unique_atoms.");
       }
+
+      /* just copy the data into the unique_atoms array */
+      bcopy(&(atoms[i]),&(unique_atoms[num_unique_atoms]),
+            sizeof(atom_type));
+      num_unique_atoms++;
     }
     first_call = 0;
   }


### PR DESCRIPTION
I'm honestly not sure if this one should be accepted. It DOES fix the crashing I was experiencing on Windows, and I've tested this fix on Linux, Mac, and Windows to make sure it worked for my test cases. It did succeed.

I know there is something wrong in this area (it has been resulting in crashing on Windows). But I don't exactly know what. However, when I move num_unique_atoms++ to after the if statement, it works.

So this DOES fix a bug with crashing on Windows, and in my tests, no new bugs were introduced. The only problem is that I don't know why this fixes it... it appears that removing the call to my_realloc() might be the fix.