### PR TITLE
Add special case for MOs print all if left empty, 0, negative, etc.

### DIFF
--- a/tightbind/fileio.c
+++ b/tightbind/fileio.c
@@ -2361,7 +2361,12 @@ calculation.\n");
 
         /* first read out the number of MOs to print */
         skipcomments(infile,instring,FATAL);
-        sscanf(instring,"%d",&(details->num_MOs_to_print));
+        if ( strstr(instring,"all") ) {
+          /* special case for "all" */
+          details->num_MOs_to_print = -1;
+        } else {
+          sscanf(instring,"%d",&(details->num_MOs_to_print));
+        }
 
         if (details->num_MOs_to_print > 0) {
           /* If num MOs is empty, etc. we'll assume it's all MOs

--- a/tightbind/fileio.c
+++ b/tightbind/fileio.c
@@ -2363,17 +2363,23 @@ calculation.\n");
         skipcomments(infile,instring,FATAL);
         sscanf(instring,"%d",&(details->num_MOs_to_print));
 
-        /* get memory */
-        details->MOs_to_print = (int *)calloc(details->num_MOs_to_print,
-                                              sizeof(int));
-        if(!details->MOs_to_print)fatal("Can't get memory for MOs_to_print.");
+        if (details->num_MOs_to_print > 0) {
+          /* If num MOs is empty, etc. we'll assume it's all MOs
+            and handle later once we know how many actually exist
+          */
 
-        /* now read out the MOs that will be printed */
-        for(i=0;i<details->num_MOs_to_print;i++){
-          skipcomments(infile,instring,FATAL);
-          sscanf(instring,"%d",&(details->MOs_to_print[i]));
-          details->MOs_to_print[i]--;
-        }
+          /* get memory */
+          details->MOs_to_print = (int *)calloc(details->num_MOs_to_print,
+                                                sizeof(int));
+          if(!details->MOs_to_print)fatal("Can't get memory for MOs_to_print.");
+
+          /* now read out the MOs that will be printed */
+          for(i=0;i<details->num_MOs_to_print;i++){
+            skipcomments(infile,instring,FATAL);
+            sscanf(instring,"%d",&(details->MOs_to_print[i]));
+            details->MOs_to_print[i]--;
+          }
+        } /* end of num_MOs_to_print > 0 */
       } /* end of keyword MO PRINT */
       /*----------------------------------------------------------------------*/
       else if( strstr(instring,"PRINT") ){
@@ -2787,5 +2793,3 @@ calculation.\n");
 
    The preceding message was a big joke.
 ***************************************************************************************/
-
-

--- a/tightbind/genutil.c
+++ b/tightbind/genutil.c
@@ -1342,7 +1342,7 @@ void print_MOs(details,num_orbs,eigenset,kpoint,unique_atoms,num_unique_atoms,
     if(!MO_file) fatal("Can't open MO file.");
 
     /* If num MOs is empty, etc. we'll assume it's all MOs */
-    if (details->num_MOs_to_print <= 0) {
+    if (details->num_MOs_to_print < 0) {
       details->num_MOs_to_print = num_orbs;
 
       /* get memory */

--- a/tightbind/genutil.c
+++ b/tightbind/genutil.c
@@ -1341,6 +1341,20 @@ void print_MOs(details,num_orbs,eigenset,kpoint,unique_atoms,num_unique_atoms,
     MO_file = fopen(filename,"w+");
     if(!MO_file) fatal("Can't open MO file.");
 
+    /* If num MOs is empty, etc. we'll assume it's all MOs */
+    if (details->num_MOs_to_print <= 0) {
+      details->num_MOs_to_print = num_orbs;
+
+      /* get memory */
+      details->MOs_to_print = (int *)calloc(num_orbs, sizeof(int));
+      if(!details->MOs_to_print)fatal("Can't get memory for MOs_to_print.");
+
+      /* now read out the MOs that will be printed */
+      for(i=0;i<details->num_MOs_to_print;i++){
+        details->MOs_to_print[i] = i;
+      }
+    } /* end of num_MOs_to_print <= 0 */
+
     /* write the atomic parms */
     fprintf(MO_file,"#begin_parms\n");
     for(i=0;i<num_unique_atoms;i++){

--- a/tightbind/kpoints.c
+++ b/tightbind/kpoints.c
@@ -493,10 +493,9 @@ void loop_over_k_points(cell,details,overlapR,hamilR,overlapK,hamilK,
                             properties,avg_prop_info,
                             num_orbs,orbital_lookup_table);
 
-        if(details->num_MOs_to_print > 0) print_MOs(details,num_orbs,eigenset,i,
-                                                    unique_atoms,num_unique_atoms,
-                                                    cell->num_atoms,orbital_lookup_table);
-
+        print_MOs(details,num_orbs,eigenset,i,
+                  unique_atoms,num_unique_atoms,
+                  cell->num_atoms,orbital_lookup_table);
 
         if(details->num_FMO_frags != 0 ){
           postprocess_FMO(cell,details,overlapR,hamilR,overlapK,hamilK,
@@ -539,6 +538,3 @@ void loop_over_k_points(cell,details,overlapR,hamilR,overlapK,hamilK,
   if( details->dump_overlap) close(overlap_file);
 
 }
-
-
-

--- a/tightbind/kpoints.c
+++ b/tightbind/kpoints.c
@@ -493,9 +493,12 @@ void loop_over_k_points(cell,details,overlapR,hamilR,overlapK,hamilK,
                             properties,avg_prop_info,
                             num_orbs,orbital_lookup_table);
 
-        print_MOs(details,num_orbs,eigenset,i,
+        if (details->num_MOs_to_print != 0) {
+          print_MOs(details,num_orbs,eigenset,i,
                   unique_atoms,num_unique_atoms,
                   cell->num_atoms,orbital_lookup_table);
+
+        }
 
         if(details->num_FMO_frags != 0 ){
           postprocess_FMO(cell,details,overlapR,hamilR,overlapK,hamilK,


### PR DESCRIPTION
e.g.,
```
mo print
all
```

Fairly minor modifications, but really useful, e.g. Avogadro.