### PR TITLE
Add some install instructions to CMakeLists.txt

### DIFF
--- a/tightbind/CMakeLists.txt
+++ b/tightbind/CMakeLists.txt
@@ -152,3 +152,14 @@ if(BUILD_STATIC)
   endif(APPLE)
 
 endif(BUILD_STATIC)
+
+# Install instructions
+set(YAEHMOP_INSTALL_HDRS
+  bind.h
+  prototypes.h
+  symmetry.h
+)
+
+install(TARGETS bind DESTINATION bin)
+install(TARGETS yaehmop_eht DESTINATION lib)
+install(FILES ${YAEHMOP_INSTALL_HDRS} DESTINATION include)


### PR DESCRIPTION
When including yaehmop in another library, it can be
helpful to have some install instructions. This provides
a basic set.