### PR TITLE
Modify the header install path for yaehmop

### DIFF
--- a/tightbind/CMakeLists.txt
+++ b/tightbind/CMakeLists.txt
@@ -160,6 +160,8 @@ set(YAEHMOP_INSTALL_HDRS
   symmetry.h
 )
 
+set(YAEHMOP_INCLUDE_DIR "include/yaehmop")
+
 install(TARGETS bind DESTINATION bin)
 install(TARGETS yaehmop_eht DESTINATION lib)
-install(FILES ${YAEHMOP_INSTALL_HDRS} DESTINATION include)
+install(FILES ${YAEHMOP_INSTALL_HDRS} DESTINATION "${YAEHMOP_INCLUDE_DIR}")


### PR DESCRIPTION
This is done so that in other projects, we can include
the header files like this:

#include <yaehmop/bind.h>

Instead of like this:

#include <bind.h>

It is just to clarify which library we are using...